### PR TITLE
disable , -networkd  and clean up

### DIFF
--- a/90-default.preset
+++ b/90-default.preset
@@ -1,6 +1,9 @@
 # tpg@mandriva.org
-# By default all services are enabled in their rpm packages
-# anyways just override it here
+# By default all services have to be enabled in their rpm packages
+# Here we can force some defaults for things may need be on all the time
+
+# Core services , systemd ones make sense to enable here
+# anything else please don't.
 
 # systemd stuff
 enable remote-fs.target
@@ -8,22 +11,11 @@ enable remote-cryptsetup.target
 enable machines.target
 enable getty@tty1.service
 
-# Enable ACPI daemon
-enable acpid.*
-
 # Enable udev service
 enable systemd-udev*.service
 enable systemd-udev*.socket
 
-# Enable udisk service
-enable udisks2.service
-
-# Enable upower service
-enable upower.service
-
-# Enable polkit service
-enable polkit.service
-
+# (crazy) what is this ?
 # Enable mandriva services
 enable mandriva-everytime.service
 
@@ -33,23 +25,9 @@ enable NetworkManager-dispatcher.service
 enable ModemManager.service
 
 # Enable other system services
-enable sshd.socket
-enable atd.*
-enable crond.*
-enable rpcbind.socket
-enable bluetooth.*
-enable cups.path
-enable cups.socket
-enable cups.service
-enable cups-browsed.service
-enable cups-lpd.socket
-enable accounts-daemon.service
-enable rtkit-daemon.service
-enable usbmuxd.service
 enable man-db.*
 enable nscd.*
 enable shadow.*
-enable saned.socket
 enable systemd-bus-proxy.socket
 enable systemd-initctl.socket
 enable systemd-journald.socket
@@ -61,25 +39,12 @@ enable systemd-timesyncd.service
 enable systemd-rfkill.socket
 enable firewalld.service
 enable iptables.service
-enable realmd.service
-enable xinetd.service
-
-# Storage services
-enable multipathd.service
-enable blk-availability.service
-enable lvm2-monitor.*
-enable lvm2-lvmetad.*
-enable dm-event.*
-enable mdmonitor.service
 
 # Hardware services
-enable irqbalance.service
-enable lm_sensors.service
 enable uuidd.*
 enable gpm.*
-enable dkms.service
-enable cpupower.service
 
+# (crazy) that may be ok
 # Sound services
 enable alsa*.service
 enable sound.service

--- a/90-default.preset
+++ b/90-default.preset
@@ -55,8 +55,6 @@ enable systemd-initctl.socket
 enable systemd-journald.socket
 
 # Network services
-enable systemd-networkd.socket
-enable systemd-networkd.service
 enable systemd-resolved.service
 enable systemd-timedated.service
 enable systemd-timesyncd.service

--- a/99-default-disable.preset
+++ b/99-default-disable.preset
@@ -2,3 +2,5 @@
 # By default disable services which are not in 90-default.preset
 disable *
 disable systemd-firstboot.service
+disable systemd-networkd.socket
+disable systemd-networkd.service

--- a/systemd.spec
+++ b/systemd.spec
@@ -63,7 +63,9 @@ Source14:	85-display-manager.preset
 Source16:	systemd.rpmlintrc
 # (tpg) by default enable network on eth, enp0s3
 Source17:	90-enable.network
-Source18:	90-user-default.preset
+# (crazy) don't play weird games with these
+# never enable / disable like this
+#Source18:	90-user-default.preset
 Source19:	10-imx.rules
 Source20:	90-wireless.network
 # (tpg) EFI bootctl
@@ -765,7 +767,8 @@ install -m 0644 %{SOURCE17} %{buildroot}%{systemd_libdir}/network/
 install -m 0644 %{SOURCE20} %{buildroot}%{systemd_libdir}/network/
 
 # (tpg) install userspace presets
-install -m 0644 %{SOURCE18} %{buildroot}%{_prefix}/lib/%{name}/user-preset/
+# (crazy) .. but not like this
+#install -m 0644 %{SOURCE18} %{buildroot}%{_prefix}/lib/%{name}/user-preset/
 
 # Install rsyslog fragment
 mkdir -p %{buildroot}%{_sysconfdir}/rsyslog.d/


### PR DESCRIPTION
While we disable -networkd elsewhere we need disable here too or is
forced enabled all the time some preset is triggered.

Clean up default enable * of services should not be there but 
controled by the rpm's. 

Don't touch users service at all.

NOTE: we need clean all *.net* ude rules , udev_net_* scripts
and do something about blind start preset-all on %post